### PR TITLE
ci: use docker registry as docker cache to speedup build

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -59,6 +59,6 @@ docker buildx build \
   ${tag} \
   --build-arg CI=true \
   --build-arg GH_PERSONNAL_TOKEN="${GITHUB_TOKEN}" \
-  --cache-from type=registry,ref=${DOCKER_IMAGE}:buildcache \
-  --cache-to type=registry,ref=${DOCKER_IMAGE}:buildcache,mode=max \
+  --cache-from type=registry,ref=${DOCKER_IMAGE}-buildcache \
+  --cache-to type=registry,ref=${DOCKER_IMAGE}-buildcache,mode=max \
   .

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
I use a new tag named buildcache to speedup the build process.
This will cache build of each arch.