### PR TITLE
ci: add data branch to semantic-release

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - beta
+      - data
       - "*.x"
 jobs:
   release:

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,6 +4,8 @@ branches:
   - main
   - name: beta
     prerelease: true
+  - name: data
+    prerelease: true
 plugins:
   - - "@semantic-release/commit-analyzer"
     - preset: conventionalcommits


### PR DESCRIPTION
This allow to release a new "data-vx.x.x" version when branch are merged into data