### PR TITLE
ci: fix add default ALLOWED_CLIENT_ORIGINS to localhost:8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM elixir:1.12-alpine AS build
 ARG CI
 ARG GH_PERSONNAL_TOKEN
 
+ENV ALLOWED_CLIENT_ORIGINS='http://localhost:8080'
+
 # prepare build dir
 WORKDIR /app
 


### PR DESCRIPTION
Dans cette PR j'ai ajouté une valeur par défault à la variable `ALLOWED_CLIENT_ORIGINS` ce qui évite de devoir en définir une.

Close #121