### PR TITLE
ci: add cache version to clear cache when needed

### DIFF
--- a/.github/workflows/elixir_checks.yml
+++ b/.github/workflows/elixir_checks.yml
@@ -38,8 +38,8 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-mix-
+          key: ${{ runner.os }}-mix-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-${{ secrets.CACHE_VERSION }}-
       - name: Install dependencies
         run: mix deps.get
       - name: Compile project


### PR DESCRIPTION
GitHub Cache can contain some deps we didn't want and let it active at build-time

Signed-off-by: shiipou <shiishii@nocturlab.fr>