### PR TITLE
fix: Revert "fix: app url in invite email"

### DIFF
--- a/apps/lenra/lib/lenra/services/user_environment_access_services.ex
+++ b/apps/lenra/lib/lenra/services/user_environment_access_services.ex
@@ -6,12 +6,7 @@ defmodule Lenra.UserEnvironmentAccessServices do
   alias Lenra.{EmailWorker, EnvironmentServices, Repo, User, UserEnvironmentAccess, UserServices}
   require Logger
 
-  @lenra_env Application.compile_env!(:lenra, :lenra_env)
-  @lenra_url %{
-    "production" => "https://app.lenra.io/app",
-    "staging" => "https://app.staging.lenra.io/app",
-    "dev" => "https://localhost:10000/app"
-  }
+  @app_url_prefix Application.compile_env!(:lenra_web, :app_url_prefix)
 
   def all(env_id) do
     Repo.all(
@@ -40,9 +35,7 @@ defmodule Lenra.UserEnvironmentAccessServices do
 
       env = repo.preload(env, :application)
 
-      app_url_prefix = Map.get(@lenra_url, @lenra_env, "https://localhost:10000/app")
-
-      app_link = "#{app_url_prefix}/#{env.application.service_name}"
+      app_link = "#{@app_url_prefix}/#{env.application.service_name}"
 
       add_invitation_events(user, env.application.name, app_link)
     end)

--- a/apps/lenra/test/lenra/services/user_environment_access_services_test.exs
+++ b/apps/lenra/test/lenra/services/user_environment_access_services_test.exs
@@ -15,7 +15,7 @@ defmodule Lenra.UserEnvironmentAccessServicesTest do
     UserServices
   }
 
-  @app_url_prefix "https://localhost:10000/app"
+  @app_url_prefix Application.compile_env!(:lenra_web, :app_url_prefix)
 
   setup do
     {:ok, create_and_return_application()}

--- a/config/config.exs
+++ b/config/config.exs
@@ -53,6 +53,9 @@ config :lenra_web, LenraWeb.Endpoint,
   pubsub_server: Lenra.PubSub,
   check_origin: false
 
+config :lenra_web,
+  app_url_prefix: "https://#{System.get_env("APP_HOST", "localhost:#{System.get_env("CLIENT_PORT", "10000")}")}/app"
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",


### PR DESCRIPTION
Reverts lenra-io/server#246

On `prod` env, the `compile_env` can't get the env var `lenra_env` because it's define at startup not at compile time.