### PR TITLE
fix: Add mac M1 docker image

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -58,7 +58,7 @@ mkdir -p "~/cache/${DOCKER_IMAGE}-buildcache"
 ## Platform argument for arm image : --platform "linux/amd64,linux/arm64,linux/arm" \
 docker buildx build \
   --output type=image,push=true \
-  --platform "linux/amd64" \
+  --platform "linux/amd64,linux/arm" \
   ${tag} \
   --build-arg CI=true \
   --build-arg GH_PERSONNAL_TOKEN="${GITHUB_TOKEN}" \

--- a/.github/release.sh
+++ b/.github/release.sh
@@ -58,7 +58,7 @@ mkdir -p "~/cache/${DOCKER_IMAGE}-buildcache"
 ## Platform argument for arm image : --platform "linux/amd64,linux/arm64,linux/arm" \
 docker buildx build \
   --output type=image,push=true \
-  --platform "linux/amd64,linux/arm" \
+  --platform "linux/amd64,linux/arm64" \
   ${tag} \
   --build-arg CI=true \
   --build-arg GH_PERSONNAL_TOKEN="${GITHUB_TOKEN}" \


### PR DESCRIPTION
<!-- 
Link the related issue
-->
Closes #366

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
I just added the linux/arm platform to the docker build command. This should ask buildx to build for arm architectures.
