### PR TITLE
fix: Rename Ory.Hydra to IdentityWeb.Hydra because of duplicated module

### DIFF
--- a/apps/identity_web/lib/hydra.ex
+++ b/apps/identity_web/lib/hydra.ex
@@ -1,4 +1,4 @@
-defmodule ORY.Hydra do
+defmodule IdentityWeb.Hydra do
   @moduledoc """
   Temporary fix to get the new Hydra 2 API working with this library.
   Can be deleted as soon as the official library is updated :

--- a/apps/identity_web/lib/identity_web/hydra_helper.ex
+++ b/apps/identity_web/lib/identity_web/hydra_helper.ex
@@ -16,8 +16,8 @@ defmodule IdentityWeb.HydraHelper do
 
   def get_login_request(login_challenge) do
     %{login_challenge: login_challenge}
-    |> ORY.Hydra.get_login_request()
-    |> ORY.Hydra.request(hydra_config())
+    |> IdentityWeb.Hydra.get_login_request()
+    |> IdentityWeb.Hydra.request(hydra_config())
   end
 
   def accept_login(login_challenge, subject, remember \\ false) do
@@ -27,16 +27,16 @@ defmodule IdentityWeb.HydraHelper do
       remember: remember,
       remember_for: @remember_for
     }
-    |> ORY.Hydra.accept_login_request()
-    |> ORY.Hydra.request(hydra_config())
+    |> IdentityWeb.Hydra.accept_login_request()
+    |> IdentityWeb.Hydra.request(hydra_config())
   end
 
   def get_consent_request(consent_challenge) do
     # The "Consent request" contain data about the current consent request.
     # We request hydra to retreive these data.
     %{consent_challenge: consent_challenge}
-    |> ORY.Hydra.get_consent_request()
-    |> ORY.Hydra.request(hydra_config())
+    |> IdentityWeb.Hydra.get_consent_request()
+    |> IdentityWeb.Hydra.request(hydra_config())
   end
 
   def accept_consent(
@@ -54,8 +54,8 @@ defmodule IdentityWeb.HydraHelper do
       remember: remember,
       remember_for: @remember_for
     }
-    |> ORY.Hydra.accept_consent_request()
-    |> ORY.Hydra.request(hydra_config())
+    |> IdentityWeb.Hydra.accept_consent_request()
+    |> IdentityWeb.Hydra.request(hydra_config())
   end
 
   def reject_consent(consent_challenge) do
@@ -64,8 +64,8 @@ defmodule IdentityWeb.HydraHelper do
       error: :consent_denied,
       error_description: "The resource owner did not consent."
     }
-    |> ORY.Hydra.reject_consent_request()
-    |> ORY.Hydra.request(hydra_config())
+    |> IdentityWeb.Hydra.reject_consent_request()
+    |> IdentityWeb.Hydra.request(hydra_config())
   end
 
   def hydra_url do


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

<!-- 
Link the related issue
-->
Closes #

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->

Rename Ory.Hydra to IdentityWeb.Hydra because of duplicated module that exist on the Ory.Hydra dependency that make the release build to fail.

Local build show a warning but still can be build.

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one


### I included unit tests that cover my changes
  - [ ] 👍 yes
  - [x] 🙅 no, because they aren't needed
  - [ ] 🙋 no, because I need help


### I added/updated the documentation about my changes

- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


## Technical highlight/advice
<!-- 
    Is there any complex point you want to highlight ?
    Do you need advice on specific point of your code ?
    Tell us here.
-->
