### PR TITLE
fix: Create a scale to zero config to disable it when not needed

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -102,7 +102,8 @@ config :application_runner,
   env: System.get_env("ENVIRONMENT", "dev"),
   listeners_timeout: 1 * 60 * 60 * 1000,
   view_timeout: 1 * 30 * 1000,
-  manifest_timeout: 1 * 30 * 1000
+  manifest_timeout: 1 * 30 * 1000,
+  scale_to_zero: false
 
 config :application_runner, :mongo,
   hostname: System.get_env("MONGO_HOSTNAME", "localhost"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -64,7 +64,8 @@ if config_env() == :prod do
     listeners_timeout: String.to_integer(System.fetch_env!("LISTENERS_TIMEOUT")),
     view_timeout: String.to_integer(System.fetch_env!("VIEW_TIMEOUT")),
     manifest_timeout: String.to_integer(System.fetch_env!("MANIFEST_TIMEOUT")),
-    env: System.fetch_env!("ENVIRONMENT")
+    env: System.fetch_env!("ENVIRONMENT"),
+    scale_to_zero: System.get_env("SCALE_TO_ZERO", "true") == "true",
 
   config :application_runner, ApplicationRunner.Repo,
     username: System.fetch_env!("POSTGRES_USER"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -65,7 +65,7 @@ if config_env() == :prod do
     view_timeout: String.to_integer(System.fetch_env!("VIEW_TIMEOUT")),
     manifest_timeout: String.to_integer(System.fetch_env!("MANIFEST_TIMEOUT")),
     env: System.fetch_env!("ENVIRONMENT"),
-    scale_to_zero: System.get_env("SCALE_TO_ZERO", "true") == "true",
+    scale_to_zero: System.get_env("SCALE_TO_ZERO", "true") == "true"
 
   config :application_runner, ApplicationRunner.Repo,
     username: System.fetch_env!("POSTGRES_USER"),

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -54,6 +54,7 @@ This document provides a list of the environment variables that need to be set f
 - `LISTENERS_TIMEOUT`: The timeout for listeners in the application runner. Must be converted to an integer.
 - `VIEW_TIMEOUT`: The timeout for views in the application runner. Must be converted to an integer.
 - `MANIFEST_TIMEOUT`: The timeout for manifests in the application runner. Must be converted to an integer.
+- `SCALE_TO_ZERO`: If set to true, the application runner will scale applications to zero when they are not in use. Default is "true".
 
 ## MongoDB Configuration
 

--- a/libs/application_runner/config/config.exs
+++ b/libs/application_runner/config/config.exs
@@ -26,7 +26,8 @@ config :application_runner,
   env: "dev",
   faas_url: System.get_env("FAAS_URL", "https://openfaas-dev.lenra.me"),
   faas_auth: System.get_env("FAAS_AUTH", "Basic YWRtaW46Z0Q4VjNHR1YxeUpS"),
-  faas_registry: System.get_env("FAAS_REGISTRY", "registry.gitlab.com/lenra/platform/lenra-ci")
+  faas_registry: System.get_env("FAAS_REGISTRY", "registry.gitlab.com/lenra/platform/lenra-ci"),
+  scale_to_zero: true
 
 config :application_runner, :mongo,
   hostname: "localhost",

--- a/libs/application_runner/lib/environment/dynamic_supervisor.ex
+++ b/libs/application_runner/lib/environment/dynamic_supervisor.ex
@@ -14,8 +14,6 @@ defmodule ApplicationRunner.Environment.DynamicSupervisor do
 
   require Logger
 
-  @scale_to_zero Application.fetch_env!(:application_runner, :scale_to_zero)
-
   @doc false
   def start_link(opts) do
     Logger.debug("#{__MODULE__} start_link with #{inspect(opts)}")
@@ -38,7 +36,7 @@ defmodule ApplicationRunner.Environment.DynamicSupervisor do
     )
 
     start_result =
-      if @scale_to_zero do
+      if Application.fetch_env!(:application_runner, :scale_to_zero) do
         ApplicationServices.start_app(env_metadata.function_name)
       else
         {:ok, nil}

--- a/libs/application_runner/lib/monitor/environment_monitor.ex
+++ b/libs/application_runner/lib/monitor/environment_monitor.ex
@@ -8,6 +8,8 @@ defmodule ApplicationRunner.Monitor.EnvironmentMonitor do
 
   require Logger
 
+  @scale_to_zero Application.fetch_env!(:application_runner, :scale_to_zero)
+
   def monitor(pid, metadata) do
     GenServer.call(__MODULE__, {:monitor, pid, metadata})
   rescue
@@ -43,7 +45,9 @@ defmodule ApplicationRunner.Monitor.EnvironmentMonitor do
     function_name = Map.get(metadata, :function_name)
     Logger.debug("#{__MODULE__} handle down #{inspect(pid)} with metadata #{inspect(metadata)}")
 
-    ApplicationServices.stop_app(function_name)
+    if @scale_to_zero do
+      ApplicationServices.stop_app(function_name)
+    end
 
     {:noreply, new_state}
   end

--- a/libs/application_runner/lib/monitor/environment_monitor.ex
+++ b/libs/application_runner/lib/monitor/environment_monitor.ex
@@ -8,8 +8,6 @@ defmodule ApplicationRunner.Monitor.EnvironmentMonitor do
 
   require Logger
 
-  @scale_to_zero Application.fetch_env!(:application_runner, :scale_to_zero)
-
   def monitor(pid, metadata) do
     GenServer.call(__MODULE__, {:monitor, pid, metadata})
   rescue
@@ -45,7 +43,7 @@ defmodule ApplicationRunner.Monitor.EnvironmentMonitor do
     function_name = Map.get(metadata, :function_name)
     Logger.debug("#{__MODULE__} handle down #{inspect(pid)} with metadata #{inspect(metadata)}")
 
-    if @scale_to_zero do
+    if Application.fetch_env!(:application_runner, :scale_to_zero) do
       ApplicationServices.stop_app(function_name)
     end
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

<!-- 
Link the related issue
-->
Closes #424 

## Description of the changes
Since I added the OpenFaaS scale to zero and scale to one, the devtool is broken since it try to call OpenFaaS that does not exist in the devtool...

This PR add a new config

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one


### I included unit tests that cover my changes
  - [ ] 👍 yes
  - [x] 🙅 no, because they aren't needed
  - [ ] 🙋 no, because I need help


### I added/updated the documentation about my changes

- [ ] 📜 README.md
- [x] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [ ] 🙅 no documentation needed

