### PR TITLE
fix: find docs query without projection

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,7 +3,7 @@
   inputs: [
     "*.{ex,exs}",
     "{config,lib,test,priv}/**/*.{ex,exs}",
-    "apps/*/{config,lib,test,priv}/**/*.{ex,exs}"
+    "{apps,libs}/*/{config,lib,test,priv}/**/*.{ex,exs}"
   ],
   line_length: 120
 ]

--- a/libs/application_runner/lib/controllers/docs_controller.ex
+++ b/libs/application_runner/lib/controllers/docs_controller.ex
@@ -213,9 +213,7 @@ defmodule ApplicationRunner.DocsController do
              doc_id,
              transaction_id
            ]) do
-      Logger.debug(
-        "#{__MODULE__} respond to #{inspect(conn.method)} on #{inspect(conn.request_path)} with status :ok"
-      )
+      Logger.debug("#{__MODULE__} respond to #{inspect(conn.method)} on #{inspect(conn.request_path)} with status :ok")
 
       reply(conn)
     end
@@ -230,9 +228,7 @@ defmodule ApplicationRunner.DocsController do
       ) do
     with :ok <-
            MongoInstance.run_mongo_task(env.id, MongoStorage, :delete_doc, [env.id, coll, doc_id]) do
-      Logger.debug(
-        "#{__MODULE__} respond to #{inspect(conn.method)} on #{inspect(conn.request_path)} with status :ok"
-      )
+      Logger.debug("#{__MODULE__} respond to #{inspect(conn.method)} on #{inspect(conn.request_path)} with status :ok")
 
       reply(conn)
     end
@@ -278,7 +274,15 @@ defmodule ApplicationRunner.DocsController do
     end
   end
 
-  def find(conn, %{"coll" => coll}, filter, %{environment: env}, replace_params) do
+  def find(
+        conn,
+        %{"coll" => coll},
+        %{
+          "query" => query
+        },
+        %{environment: env},
+        replace_params
+      ) do
     Logger.warning(
       "This form of query is deprecated, prefer using: {query: <your query>, projection: {projection}}, more info at: https://www.mongodb.com/docs/manual/reference/method/db.collection.find/#mongodb-method-db.collection.find"
     )
@@ -287,7 +291,7 @@ defmodule ApplicationRunner.DocsController do
            MongoInstance.run_mongo_task(env.id, MongoStorage, :filter_docs, [
              env.id,
              coll,
-             Parser.replace_params(filter, replace_params)
+             Parser.replace_params(query, replace_params)
            ]) do
       Logger.debug(
         "#{__MODULE__} respond to #{inspect(conn.method)} on #{inspect(conn.request_path)} with res #{inspect(docs)}"
@@ -370,9 +374,7 @@ defmodule ApplicationRunner.DocsController do
              transaction_id,
              env.id
            ]) do
-      Logger.debug(
-        "#{__MODULE__} respond to #{inspect(conn.method)} on #{inspect(conn.request_path)} with status :ok"
-      )
+      Logger.debug("#{__MODULE__} respond to #{inspect(conn.method)} on #{inspect(conn.request_path)} with status :ok")
 
       reply(conn)
     end
@@ -390,9 +392,7 @@ defmodule ApplicationRunner.DocsController do
              transaction_id,
              env.id
            ]) do
-      Logger.debug(
-        "#{__MODULE__} respond to #{inspect(conn.method)} on #{inspect(conn.request_path)} with status :ok"
-      )
+      Logger.debug("#{__MODULE__} respond to #{inspect(conn.method)} on #{inspect(conn.request_path)} with status :ok")
 
       reply(conn)
     end


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
When calling the find endpoint for documents without defining the projection property in the payload, the endpoint act like is not waiting for an object with the query in it but directly the query.

This PR fixes it to always wait for an object with a query property.

## How to test my changes
<!-- 
  - How to start the project. Any other dependancies to update ? Any database migration ?
  - Step-by-step guide to reproduce the bug or test the new feature.

  Try to be rather explicit but keep it as simple as possible.

  Example : 
  - On server : 
    - `git checkout implement-cgu-validation`
    - `mix ecto.reset`
    - `mix ecto.migrate`
    - `mix phx.server`
  Use the thunder client in vscode : 
  - Register/Login (get the token)
  - Try to access this api without validating CGU : GET /api/apps. It should fail.
  - Validate the CGU ising the API POST /api/cgu/accept
  - Access the API agail, now it should work.
-->


## Checklist
- [ ] I didn't over-scope my PR
- [ ] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [ ] 🙅 no documentation needed


