### PR TITLE
fix: Consent Page app name

### DIFF
--- a/apps/identity_web/lib/identity_web/views/oauth_helpers.ex
+++ b/apps/identity_web/lib/identity_web/views/oauth_helpers.ex
@@ -69,7 +69,7 @@ defmodule IdentityWeb.OAuthHelpers do
   Get the OAuth client name.
   """
   def get_client_name(%{"metadata" => %{"environment_id" => env_id}})
-      when is_binary(env_id) do
+      when is_integer(env_id) do
     # get the app name from the environment id
     {:ok, app} = Lenra.Apps.fetch_app_for_env(env_id)
     app.name


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->
Closes https://github.com/lenra-io/server/issues/527

This was just a bug in the way we match on the env_id. As you can see in this PR, there was a is_binary check on the environment but this could never match because the env_id is an integer.

I change the is_binary to a is_integer and now this works properly.

## How to test my changes

You can run the app-molny with a local setup of the server using this branch and you will see on the consent page that the app name is properly displayed.

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


