### PR TITLE
fix: Hydra OAuth Token invalid when server is reset

### DIFF
--- a/apps/identity_web/lib/identity_web/controllers/user_auth_controller.ex
+++ b/apps/identity_web/lib/identity_web/controllers/user_auth_controller.ex
@@ -147,18 +147,27 @@ defmodule IdentityWeb.UserAuthController do
 
       case Accounts.get_user(response.body["subject"]) do
         # In case the user from the token is nil, the token is invalid
-        nil -> {:error, {:invalid_token, "The token is invalid.", 403}}
-        res -> redirect_next_step(conn, res, login_challenge, true)
+        nil ->
+          conn
+          |> redirect_to_register(login_challenge)
+
+        res ->
+          redirect_next_step(conn, res, login_challenge, true)
       end
     else
       # client = response.body["client"]
       conn
-      |> delete_session(:user_id)
-      |> delete_session(:remember)
-      |> delete_session(:email)
-      |> put_session(:login_challenge, login_challenge)
-      |> redirect(to: Routes.user_auth_path(conn, :register_page))
+      |> redirect_to_register(login_challenge)
     end
+  end
+
+  defp redirect_to_register(conn, login_challenge) do
+    conn
+    |> delete_session(:user_id)
+    |> delete_session(:remember)
+    |> delete_session(:email)
+    |> put_session(:login_challenge, login_challenge)
+    |> redirect(to: Routes.user_auth_path(conn, :register_page))
   end
 
   def new(conn, _params),


### PR DESCRIPTION

## About this PR

Very closely linked to https://github.com/lenra-io/devtool/issues/210

## Technical highlight/advice

Do not return errors when the oauth token is invalid, just redirect to the register page as we don't know what could have caused the issue. It is better to get a new token than trying to fix an unfixable data corruption.


## How to test my changes

Please see @taorepoara comments on https://github.com/lenra-io/devtool/issues/210 for testing instructions. You basically need to start a server, register and connect. Then you need to reset the server and try to log in back into it with the same old oauth token. It should redirect you to the register page. 

Before my change it just showed an error.

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


